### PR TITLE
modified component to render within touchable using setnativeprops

### DIFF
--- a/react-native-responsive-image.js
+++ b/react-native-responsive-image.js
@@ -3,7 +3,7 @@ var Device = require('./device');
 var { Image } = React;
 
 var ResponsiveImage = React.createClass({
-    setNativeProps (nativeProps) {
+    setNativeProps: function(nativeProps) {
         this._root.setNativeProps(nativeProps);
     },
     render: function () {

--- a/react-native-responsive-image.js
+++ b/react-native-responsive-image.js
@@ -10,7 +10,9 @@ var ResponsiveImage = React.createClass({
         var width = Math.ceil(this.props.initWidth * Device.scale);
         var height = Math.ceil(this.props.initHeight * Device.scale);
         return (
-            <Image style={[{width: width, height: height}, this.props.style]} source={this.props.source}>
+            <Image style={[{width: width, height: height}, this.props.style]}
+                   source={this.props.source}
+                   ref={component => this._root = component}>
                 {this.props.children}
             </Image>
         );

--- a/react-native-responsive-image.js
+++ b/react-native-responsive-image.js
@@ -3,6 +3,9 @@ var Device = require('./device');
 var { Image } = React;
 
 var ResponsiveImage = React.createClass({
+    setNativeProps (nativeProps) {
+        this._root.setNativeProps(nativeProps);
+    },
     render: function () {
         var width = Math.ceil(this.props.initWidth * Device.scale);
         var height = Math.ceil(this.props.initHeight * Device.scale);


### PR DESCRIPTION
When responsiveImage is wrapped within a touchable component, it complains that:

> touchable child must either be native or forward setNativeProps to a native component.

It seems to me logical to use setNativeProps method on the responiveImage component directly, as it cannot be set on the parent component by the user of the library. Hence the following added:

``` javascript
setNativeProps: function(nativeProps) {
    this._root.setNativeProps(nativeProps);
},
```
