### PR TITLE
Add support for image loading lifecycle

### DIFF
--- a/react-native-responsive-image.js
+++ b/react-native-responsive-image.js
@@ -12,7 +12,13 @@ var ResponsiveImage = React.createClass({
         return (
             <Image style={[{width: width, height: height}, this.props.style]}
                    source={this.props.source}
-                   ref={component => this._root = component}>
+                   ref={component => this._root = component}
+                   onLoadStart={this.props.onLoadStart}
+                   onProgress={this.props.onProgress}
+                   onLoad={this.props.onLoad}
+                   onError={this.props.onError}
+                   onLoadEnd={this.props.onLoadEnd}
+                   >
                 {this.props.children}
             </Image>
         );


### PR DESCRIPTION
Currently, props like `onLoad` and `onLoadStart` are not passed through to the React Native image component. This prevents us from showing spinners or implementing retry logic when dealing with large network images.

This passes along those props.
