### PR TITLE
Allow `borderRadius` prop to be applied to images

### DIFF
--- a/src/react-native-responsive-image.js
+++ b/src/react-native-responsive-image.js
@@ -22,6 +22,7 @@ export default class ResponsiveImage extends Component {
                 onError={this.props.onError}
                 onLoadEnd={this.props.onLoadEnd}
                 defaultSource={this.props.defaultSource}
+                borderRadius={this.props.borderRadius}
             >
                 {this.props.children}
             </Image>


### PR DESCRIPTION
The react-native [image component](https://facebook.github.io/react-native/docs/image.html) has a `borderRadius` prop that can be applied directly, instead of via styles, since Android has issues adding a radius to an image that has children. This change allows responsive images to apply the border radius prop on Android if given.